### PR TITLE
feat(toggle): Implement `bt toggle`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,18 +117,21 @@ impl Bluez {
         Ok(dev_paths)
     }
 
-    fn get_device_proxy<'a>(&'a self, path: &'a str) -> zbus::Result<BluezDeviceProxy<'a>> {
-        let proxy = BluezDeviceProxy::builder(&self.connection).path(path)?;
-        proxy.build()
-    }
+    fn build_proxy<'a, T>(&self, path: Option<&'a str>) -> zbus::Result<T>
+    where
+        T: zbus::blocking::proxy::ProxyImpl<'a> + From<zbus::Proxy<'a>>,
+    {
+        let mut proxy_builder = T::builder(&self.connection);
 
-    fn get_battery_proxy<'a>(&'a self, path: &'a str) -> zbus::Result<BluezDeviceBatteryProxy<'a>> {
-        let proxy = BluezDeviceBatteryProxy::builder(&self.connection).path(path)?;
-        proxy.build()
+        if let Some(path) = path {
+            proxy_builder = proxy_builder.path(path)?;
+        }
+
+        proxy_builder.build()
     }
 
     pub fn power_state(&self) -> zbus::Result<BluezPowerState> {
-        let adapter_proxy = BluezAdapterProxy::new(&self.connection)?;
+        let adapter_proxy: BluezAdapterProxy = self.build_proxy(None)?;
         let result = adapter_proxy.power_state().map(BluezPowerState::from)?;
 
         Ok(result)
@@ -140,14 +143,15 @@ impl Bluez {
         Ok(dev_paths
             .into_iter()
             .filter_map(|dev_path| {
-                let dev_proxy = self.get_device_proxy(&dev_path).ok()?;
+                let dev_proxy: BluezDeviceProxy = self.build_proxy(Some(&dev_path)).ok()?;
 
                 let is_connected = dev_proxy.connected().ok()?;
                 if !is_connected {
                     return None;
                 }
 
-                let battery_proxy = self.get_battery_proxy(&dev_path).ok()?;
+                let battery_proxy: BluezDeviceBatteryProxy =
+                    self.build_proxy(Some(&dev_path)).ok()?;
 
                 let address = dev_proxy.address().ok()?;
                 let alias = dev_proxy.alias().ok()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ use zbus::zvariant::OwnedObjectPath;
 pub trait BluezAdapter {
     #[zbus(property, name = "PowerState")]
     fn power_state(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn set_powered(&self, power_state: bool) -> zbus::Result<()>;
 }
 
 #[proxy(
@@ -68,6 +71,26 @@ impl From<String> for BluezPowerState {
             BluezPowerState::On
         } else {
             BluezPowerState::Off
+        }
+    }
+}
+
+impl std::ops::Not for BluezPowerState {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            BluezPowerState::On => Self::Off,
+            BluezPowerState::Off => Self::On,
+        }
+    }
+}
+
+impl From<&BluezPowerState> for bool {
+    fn from(value: &BluezPowerState) -> Self {
+        match value {
+            BluezPowerState::On => true,
+            BluezPowerState::Off => false,
         }
     }
 }
@@ -137,6 +160,16 @@ impl Bluez {
         Ok(result)
     }
 
+    pub fn toggle_power_state(&self) -> zbus::Result<BluezPowerState> {
+        let adapter_proxy: BluezAdapterProxy = self.build_proxy(None)?;
+        let prev_state = adapter_proxy.power_state().map(BluezPowerState::from)?;
+
+        let new_state = !prev_state;
+        adapter_proxy.set_powered(bool::from(&new_state))?;
+
+        Ok(new_state)
+    }
+
     pub fn connected_devs(&self) -> zbus::Result<Vec<BluezConnectedDev>> {
         let dev_paths = self.get_dev_object_paths()?;
 
@@ -184,6 +217,16 @@ pub fn status(f: &mut impl io::Write) -> Result<(), Box<dyn error::Error>> {
         buf.push_str(&dev.to_string())
     }
 
+    f.write_all(buf.as_bytes())?;
+
+    Ok(())
+}
+
+pub fn toggle(f: &mut impl io::Write) -> Result<(), Box<dyn error::Error>> {
+    let bluez = Bluez::new()?;
+    let toggled_power_state = bluez.toggle_power_state()?;
+
+    let buf = format!("bluetooth: {}", toggled_power_state);
     f.write_all(buf.as_bytes())?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
     if let Some(subcommand) = args.command {
         match subcommand {
             BtCommand::Status => bt::status(&mut stdout),
-            BtCommand::Toggle => todo!(),
+            BtCommand::Toggle => bt::toggle(&mut stdout),
             BtCommand::Scan { args } => todo!(),
             BtCommand::Connect { args } => todo!(),
             BtCommand::Disconnect { force } => todo!(),


### PR DESCRIPTION
The subcommand `bt toggle` (or `bt t` with alias) is implemented by setting the `org.bluez.Adapter1.Powered` property accordingly.

## Usage

```bash
# Assume that BT is enabled.
bt toggle
# bluetooth: disabled

# Assume that BT is disabled.
bt t
# bluetooth: enabled
```

## Other Changes

A generic method `build_proxy` is added to prevent creating duplicate methods for each individual DBus proxy.