### PR TITLE
refactor(ls-args): Create ListDevicesArgs struct

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Parser, Subcommand, arg, command};
 
+use crate::list_devices::ListDevicesArgs;
+
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
@@ -19,17 +21,8 @@ pub enum BtCommand {
 
     #[clap(visible_alias = "ls")]
     ListDevices {
-        /// Filter the table output based on given keys.
-        #[arg(short, long, value_delimiter = ',')]
-        columns: Option<Vec<BtListingKey>>,
-
-        /// Filter the terse output based on given keys.
-        #[arg(short, long, value_delimiter = ',')]
-        values: Option<Vec<BtListingKey>>,
-
-        /// Filter output based on device status.
-        #[arg(short, long)]
-        status: Option<BtListingStatusKey>,
+        #[command(flatten)]
+        args: ListDevicesArgs,
     },
 
     /// Scan available devices.
@@ -60,22 +53,4 @@ pub struct ScanArgs {
     /// Set the duration of the scan.
     #[arg(short, long, default_value_t = 5u8)]
     duration: u8,
-}
-
-#[derive(Debug, Copy, Clone, clap::ValueEnum)]
-pub enum BtListingKey {
-    Alias,
-    Address,
-    Connected,
-    Trusted,
-    Bonded,
-    Paired,
-}
-
-#[derive(Debug, Copy, Clone, clap::ValueEnum)]
-pub enum BtListingStatusKey {
-    Connected,
-    Trusted,
-    Bonded,
-    Paired,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             BtCommand::Scan { args } => todo!(),
             BtCommand::Connect { args } => todo!(),
             BtCommand::Disconnect { force } => todo!(),
-            BtCommand::ListDevices {
-                columns,
-                values,
-                status,
-            } => bt::list_devices(&mut stdout, columns, values, status),
+            BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),
         }
     } else {
         bt::status(&mut stdout)

--- a/todo-api.md
+++ b/todo-api.md
@@ -1,0 +1,119 @@
+# TODO `bt` API
+
+Here is the current features that are offered by `bluetooth`:
+
+- Enable/Disable bluetooth - done
+- Scan devices - done
+- Connect to a specific device from scan results, with rescans - done
+- Disconnect from device(s) - done
+
+And when `bluetooth` first runs, it shows the status:
+
+- BT on or off - done
+- Connected devices if any. - done
+
+So based on this, here is the API:
+
+## Status - done
+
+```bash
+$ bt status
+bluetooth: enabled/disabled
+connected device(s): 
+dev1:addr1 (battery: %percentage1)
+dev2:addr2 (battery: %percentage2)
+```
+
+The status is really straightforward, I need to see the bluetooth driver status, along with the connected devices if any.
+
+## Toggle - done
+
+```bash
+$ bt toggle
+# Bluetooth status: disabled
+
+$ bt toggle
+# Bluetooth status: enabled
+```
+
+For the toggle, it's pretty easy as well. It should just switch the BT status and show the updated status to the user.
+
+## List Devices - done
+
+```bash
+$ bt ls
+DEVICE ADDRESS CONNECTED TRUSTED PAIRED BONDED
+dev1   xxxxxxx   false     true    false   false
+
+$ bt ls -c device,connected
+DEVICE CONNECTED
+dev1     false
+
+$ bt ls -v device,connected
+dev1/false
+
+$ bt ls -s trusted|paired|connected|bonded # filter output based on status
+```
+
+List devices command can be used to see the status of the available devices on the host.
+Like `nmcli`, it can show a table or a terse output if needed.
+
+The output should be able to show filtered output.
+
+This is probably the hardest command of `bt`, but lets see how it goes.
+
+## Scan
+
+```bash
+$ bt scan
+# Dev1
+# Dev2
+# Dev3
+
+$ bt scan --duration 10
+# Shows results after 10 secs.
+```
+
+Scan needs to show a list of available devices that can be connected later on.
+Optionally, it may include a `--duration` flag to scan for X seconds.
+The default duration may be something like 5 seconds.
+
+## Connect
+
+```bash
+$ bt connect
+# (0) Dev1
+# (1) Dev2
+# (2) Dev3
+# Select the device you wish to connect (enter s to refresh the list):
+
+$ bt connect --duration 10
+# Shows results after 10 secs.
+```
+
+Now, the actual connection happens via MAC addresses, but making users write the MAC addresses is not really intuitive.
+Therefore, connect should not require MAC addresses, it should be interactive and show the users a scan result to let them choose from.
+The underlying implementation should use the corresponding MAC addresses.
+
+It should also be able to accept the same duration flag that is used for `bt scan`.
+
+Now, there was a bug in `bluetooth`, which was actually a feature of `bluetoothctl`.
+
+`bluetoothctl` scan does not include the currently known devices that are also broadcasting. So `bt` should add the known devices to the list along with the scan results.
+
+## Disconnect
+
+```bash
+$ bt disconnect
+# (0) Dev1
+# (1) Dev2
+# (2) Dev3
+# Select the device to disconnect:
+
+$ bt disconnect -f
+# Same with above but deletes the dev from the list of known devices.
+```
+
+Disconnect is pretty straightforward.
+It should accept a selection from the user (interactive), and then disconnect from it.
+It may additionally have a `--force` flag to remove the device from the list of known devices after disconnecting from it.

--- a/todo-commit.md
+++ b/todo-commit.md
@@ -1,0 +1,1 @@
+# TODO commit (status)

--- a/todo-module-tree.md
+++ b/todo-module-tree.md
@@ -1,0 +1,6 @@
+# TODO Module Tree
+
+tree for `bt ls`:
+
+bin crate -> api mod
+          -> lib root -> list_devices mod -> api mod

--- a/todo-scan.md
+++ b/todo-scan.md
@@ -1,0 +1,32 @@
+# TODO BT Scan Flow
+
+1 - Find out how a BT scan is done through Bluez DBus.
+2 - Create the `bt scan` API.
+3 - Create necessary Bluez proxies through `zbus` if necessary.
+4 - Use the `--duration` flag to set the scan duration.
+5 - Make sure that scan results contain previously connected/bonded/trusted/paired devices. This was a bug in `bluetooth` shell script that forced me to connect by writing the mac address by hand.
+
+## Notes taken during the implementation
+
+
+### Showing previously connected devices after scan
+
+About #5, it is actually not correct to show previously connected/bonded/trusted/paired devices. Because there may be a case where `bt` shows the devices, but they are actually not connectable.
+
+Instead, `bt scan` should always show newly connected devices instead, like `bluetoothctl` does.
+
+The bug in `bluetooth` shell script can be solved during the `bt connect` implementation.
+In there, we can actually show the known devices as well because users tend to connect to their known devices, and before doing so they usually set the device to pairing mode.
+ 
+So, `bt scan` should work exactly like `bluetooth` shell script, in a way that it only shows newly discovered devices that have their aliases set by the user.
+
+If the alias is not set, then Bluez set it to remote device's address, replacing `:` with `-`.
+
+### Showing the scan result to user
+
+In general, `bt` should follow a single standard for showing its output to users.
+
+Since we implemented a table/terse output formatting in `bt ls`, we can continue to do so for `bt scan` as well.
+However, this means the formatting logic needs to be extracted from `bt ls` and should be moved under a different module, which should be usable by both `bt ls` and `bt scan`.
+
+The same formatting will be used for `bt connect` in the future as well, or `bt disconnect`.

--- a/todo-zbus-mapping.md
+++ b/todo-zbus-mapping.md
@@ -1,0 +1,37 @@
+```rust
+        // let devices = result
+        //     .into_iter()
+        //     .filter_map(|(object_path, object)| {
+        //         if let Some(path) = object_path.rsplitn(2, "/").take(1).next() {
+        //             if !path.contains("dev") {
+        //                 None
+        //             } else {
+        //                 Some(object)
+        //             }
+        //         } else {
+        //             None
+        //         }
+        //     })
+        //     .filter_map(|mut object| {
+        //         let mut dev_iface = object.remove("org.bluez.Device1")?;
+
+        //         let conn_status = dev_iface.remove("Connected")?;
+        //         let is_connected = bool::try_from(conn_status).ok()?;
+        //         if !is_connected {
+        //             return None;
+        //         }
+
+        //         let alias = String::try_from(dev_iface.remove("Alias")?).ok()?;
+        //         let address = String::try_from(dev_iface.remove("Address")?).ok()?;
+
+        //         let mut batt_iface = object.remove("org.bluez.Battery1")?;
+        //         let battery = u8::try_from(batt_iface.remove("Percentage")?).ok()?;
+
+        //         Some(BluezConnectedDevStatus {
+        //             alias,
+        //             address,
+        //             battery,
+        //         })
+        //     })
+        //     .collect::<Vec<BluezConnectedDevStatus>>();
+```


### PR DESCRIPTION
This struct is created for:

- Grouping up the options that are used for `bt ls`.
- Moving the options to the place where they are intended to be used (list_devices module).

During the refactor, the enums `BtListingKey` and `BtListingStatusKey` are renamed to `ListDevicesColumn` and `DeviceStatus` to add more clarity.