### PR TITLE
feat(scan): Implement `bt scan`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
-use clap::{Args, Parser, Subcommand, arg, command};
+use clap::{Parser, Subcommand, arg, command};
 
-use crate::list_devices::ListDevicesArgs;
+use crate::{list_devices::ListDevicesArgs, scan::ScanArgs};
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -46,11 +46,4 @@ pub enum BtCommand {
         #[arg(short, long, default_value_t = false)]
         force: bool,
     },
-}
-
-#[derive(Debug, Args)]
-pub struct ScanArgs {
-    /// Set the duration of the scan.
-    #[arg(short, long, default_value_t = 5u8)]
-    duration: u8,
 }

--- a/src/bluez/proxies.rs
+++ b/src/bluez/proxies.rs
@@ -14,6 +14,10 @@ pub trait BluezAdapter {
 
     #[zbus(property)]
     fn set_powered(&self, power_state: bool) -> zbus::Result<()>;
+
+    fn start_discovery(&self) -> zbus::Result<()>;
+
+    fn stop_discovery(&self) -> zbus::Result<()>;
 }
 
 #[proxy(
@@ -41,6 +45,9 @@ pub trait BluezDevice {
 
     #[zbus(property)]
     fn address(&self) -> zbus::Result<String>;
+
+    #[zbus(property, name = "RSSI")]
+    fn rssi(&self) -> zbus::Result<i16>;
 }
 
 #[proxy(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod api;
 mod bluez;
 mod list_devices;
+mod scan;
 mod status;
 mod toggle;
 
 pub use list_devices::list_devices;
+pub use scan::scan;
 pub use status::status;
 pub use toggle::toggle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
         match subcommand {
             BtCommand::Status => bt::status(&mut stdout),
             BtCommand::Toggle => bt::toggle(&mut stdout),
-            BtCommand::Scan { args } => todo!(),
+            BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
             BtCommand::Connect { args } => todo!(),
             BtCommand::Disconnect { force } => todo!(),
             BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,0 +1,7 @@
+use std::{error, io};
+
+use crate::api::ScanArgs;
+
+pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error::Error>> {
+    todo!()
+}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,9 @@
 use std::{error, io};
 
 use clap::Args;
+use tabled::{builder::Builder, settings::Style};
+
+use crate::bluez;
 
 #[derive(Debug, Args)]
 pub struct ScanArgs {
@@ -9,21 +12,108 @@ pub struct ScanArgs {
     pub duration: u8,
 
     /// Filter the pretty output based on given columns.
-    #[arg(short, long, value_delimiter = ',')]
-    pub columns: Option<Vec<BtScanColumns>>,
+    ///
+    /// If no columns are provided, then the full pretty output is shown to the user.
+    #[arg(short, long, value_delimiter = ',', num_args = 0..)]
+    pub columns: Vec<ScanColumn>,
 
     /// Filter the terse output based on given columns.
-    #[arg(short, long, value_delimiter = ',')]
-    pub values: Option<Vec<BtScanColumns>>,
+    ///
+    /// If no columns are provided, then the full terse output is shown to the user.
+    #[arg(short, long, value_delimiter = ',', num_args = 0..)]
+    pub values: Vec<ScanColumn>,
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
-pub enum BtScanColumns {
+pub enum ScanColumn {
     Alias,
     Address,
-    RSSI,
+    Rssi,
+}
+
+const DEFAULT_LISTING_KEYS: [ScanColumn; 3] =
+    [ScanColumn::Alias, ScanColumn::Address, ScanColumn::Rssi];
+
+enum ScanOutput {
+    Pretty,
+    Terse,
+}
+
+pub trait Listable {
+    fn get_listing_field_by_column(&self, value: &ScanColumn) -> String;
+}
+
+impl Listable for bluez::Device {
+    fn get_listing_field_by_column(&self, value: &ScanColumn) -> String {
+        match value {
+            ScanColumn::Alias => self.alias(),
+            ScanColumn::Address => self.address(),
+            ScanColumn::Rssi => self.rssi().unwrap_or(0).to_string(),
+        }
+    }
+}
+
+impl From<&ScanColumn> for String {
+    fn from(value: &ScanColumn) -> Self {
+        let str = match value {
+            ScanColumn::Alias => "ALIAS",
+            ScanColumn::Address => "ADDRESS",
+            ScanColumn::Rssi => "RSSI",
+        };
+
+        str.to_string()
+    }
 }
 
 pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error::Error>> {
-    todo!()
+    let bluez = bluez::Client::new()?;
+    let scan_result = bluez.scan(&args.duration)?;
+
+    let (out_format, listing_keys) = match (&args.columns.len(), &args.values.len()) {
+        (0, 0) => (ScanOutput::Pretty, &DEFAULT_LISTING_KEYS.to_vec()),
+        (0, _) => (ScanOutput::Terse, &args.values),
+        (_, _) => (ScanOutput::Pretty, &args.columns),
+    };
+
+    let listing = scan_result.iter().map(|d| {
+        listing_keys
+            .iter()
+            .map(|k| d.get_listing_field_by_column(k))
+            .collect::<Vec<String>>()
+    });
+
+    let out_buf = match out_format {
+        ScanOutput::Pretty => create_pretty_out(listing, listing_keys),
+        ScanOutput::Terse => create_terse_out(listing),
+    };
+
+    f.write_all(out_buf.as_bytes())?;
+
+    Ok(())
+}
+pub fn create_pretty_out(
+    listing: impl Iterator<Item = Vec<String>>,
+    columns: &[ScanColumn],
+) -> String {
+    let mut builder = Builder::default();
+
+    builder.push_record(columns);
+    for row in listing {
+        builder.push_record(row);
+    }
+
+    let mut table = builder.build();
+    table.with(Style::blank());
+
+    format!("{}", table)
+}
+
+pub fn create_terse_out(listing: impl Iterator<Item = Vec<String>>) -> String {
+    listing
+        .map(|l| {
+            let mut terse_str = l.join("/");
+            terse_str.push('\n');
+            terse_str
+        })
+        .collect()
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,28 @@
 use std::{error, io};
 
-use crate::api::ScanArgs;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ScanArgs {
+    /// Set the duration of the scan.
+    #[arg(short, long, default_value_t = 5u8)]
+    pub duration: u8,
+
+    /// Filter the pretty output based on given columns.
+    #[arg(short, long, value_delimiter = ',')]
+    pub columns: Option<Vec<BtScanColumns>>,
+
+    /// Filter the terse output based on given columns.
+    #[arg(short, long, value_delimiter = ',')]
+    pub values: Option<Vec<BtScanColumns>>,
+}
+
+#[derive(Debug, Copy, Clone, clap::ValueEnum)]
+pub enum BtScanColumns {
+    Alias,
+    Address,
+    RSSI,
+}
 
 pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error::Error>> {
     todo!()


### PR DESCRIPTION
The subcommand `bt scan` (or `bt sc` with alias) is implemented through the custom Bluez DBus client.

The scanned devices are shown in different formats based on the usage:

- A pretty (table) format, for users,
- A terse format, for scripting purposes.

The implementation for different formats is similar to `bt ls`, however they are kept separate for now since the whole project is in WIP state.

## Usage

```bash
# By default, the output is shown in pretty (table) format.
# This is same with `bt scan --columns`.
$ bt scan
# ALIAS               ADDRESS             RSSI
# Realtek Bluetooth   XX:XX:XX:XX:XX:XX   -92

# For terse output, [-v | --values] can be used.
$ bt sc --values
# JBL TUNE520BT-LE/XX:XX:XX:XX:XX:XX/-97
# Realtek Bluetooth/XX:XX:XX:XX:XX:XX/-78

# The output can be filtered by specifying corresponding columns.
$ bt sc --values alias,rssi
# JBL TUNE520BT-LE/-97
# Realtek Bluetooth/-86

$ bt sc --columns alias,rssi
# ALIAS               RSSI
# Realtek Bluetooth   -84
# JBL TUNE520BT-LE    -95

# Use `--duration` to set the scan duration (seconds, max 60).
# By default, it is set to 5 seconds.
$ bt sc --duration 10
```