### PR TITLE
api(connect): Change `bt connect` API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, arg, command};
+use clap::{Args, Parser, Subcommand, arg, command};
 
 use crate::{list_devices::ListDevicesArgs, scan::ScanArgs};
 
@@ -36,7 +36,7 @@ pub enum BtCommand {
     #[clap(visible_alias = "c")]
     Connect {
         #[command(flatten)]
-        args: ScanArgs,
+        args: ConnectArgs,
     },
 
     /// Disconnect from an available device.
@@ -46,4 +46,26 @@ pub enum BtCommand {
         #[arg(short, long, default_value_t = false)]
         force: bool,
     },
+}
+
+#[derive(Debug, Args)]
+pub struct ConnectArgs {
+    /// Set the duration of the scan.
+    ///
+    /// This option is only available during the interactive mode.
+    #[arg(short, long, default_value_t = 5u8, conflicts_with = "alias")]
+    pub duration: u8,
+
+    /// Show available devices that contains the name <NAME> in their ALIAS.
+    ///
+    /// This option is only available during the interactive mode.
+    #[arg(short, long, conflicts_with = "alias")]
+    pub contains_name: Option<String>,
+
+    /// Connect to ALIAS if it the device is available.
+    ///
+    /// This option does not initiate a scan, therefore it bypasses the interactive mode completely.
+    /// This option expects the full device ALIAS, unlike --contains-name.
+    #[arg(short, long)]
+    pub alias: Option<String>,
 }


### PR DESCRIPTION
During the development of `bt scan`, it is realized that `bt connect` may require a different sets of arguments than `bt scan`.

Therefore, the API design of `bt connect` is changed. The ability to change the interactive scan format is removed completely.

Instead, it is changed to allow a simple grep through scanned devices' ALIAS and a non-interactive mode by providing the full device ALIAS for convenience.