### PR TITLE
feat(connect): Implement `bt connect`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
-use clap::{Args, Parser, Subcommand, arg, command};
+use clap::{Parser, Subcommand, arg, command};
 
-use crate::{list_devices::ListDevicesArgs, scan::ScanArgs};
+use crate::{connect::ConnectArgs, list_devices::ListDevicesArgs, scan::ScanArgs};
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -46,26 +46,4 @@ pub enum BtCommand {
         #[arg(short, long, default_value_t = false)]
         force: bool,
     },
-}
-
-#[derive(Debug, Args)]
-pub struct ConnectArgs {
-    /// Set the duration of the scan.
-    ///
-    /// This option is only available during the interactive mode.
-    #[arg(short, long, default_value_t = 5u8, conflicts_with = "alias")]
-    pub duration: u8,
-
-    /// Show available devices that contains the name <NAME> in their ALIAS.
-    ///
-    /// This option is only available during the interactive mode.
-    #[arg(short, long, conflicts_with = "alias")]
-    pub contains_name: Option<String>,
-
-    /// Connect to ALIAS if it the device is available.
-    ///
-    /// This option does not initiate a scan, therefore it bypasses the interactive mode completely.
-    /// This option expects the full device ALIAS, unlike --contains-name.
-    #[arg(short, long)]
-    pub alias: Option<String>,
 }

--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt, thread, time::Duration};
+use std::fmt;
 
 use zbus::{
     blocking::{Connection, fdo::ObjectManagerProxy},
@@ -188,14 +188,18 @@ impl Bluez {
         Ok(devs.into_iter().filter(|d| d.connected).collect())
     }
 
-    pub fn scan(&self, duration: &u8) -> zbus::Result<Vec<BluezDev>> {
-        let adapter_proxy = BluezAdapterProxy::new(&self.connection)?;
-        adapter_proxy.start_discovery()?;
+    pub fn start_discovery(&self) -> zbus::Result<()> {
+        let adapter_proxy: BluezAdapterProxy = self.build_proxy(None)?;
+        adapter_proxy.start_discovery()
+    }
 
-        thread::sleep(Duration::from_secs(u64::from(*duration)));
+    pub fn stop_discovery(&self) -> zbus::Result<()> {
+        let adapter_proxy: BluezAdapterProxy = self.build_proxy(None)?;
+        adapter_proxy.stop_discovery()
+    }
+
+    pub fn scanned_devices(&self) -> zbus::Result<Vec<BluezDev>> {
         let devs = self.devs()?;
-        adapter_proxy.stop_discovery()?;
-
         Ok(devs.into_iter().filter(|d| d.rssi.is_some()).collect())
     }
 }

--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -182,6 +182,21 @@ impl Bluez {
             .collect::<Vec<BluezDev>>())
     }
 
+    pub fn connect(&self, alias: &str) -> zbus::Result<()> {
+        let dev_paths = self.dev_object_iter()?;
+
+        for dev_path in dev_paths {
+            let dev_proxy: BluezDeviceProxy = self.build_proxy(Some(&dev_path))?;
+
+            let dev_alias = dev_proxy.alias()?;
+            if dev_alias == alias {
+                return dev_proxy.connect();
+            }
+        }
+
+        Err(zbus::Error::InterfaceNotFound)
+    }
+
     pub fn connected_devs(&self) -> zbus::Result<Vec<BluezDev>> {
         let devs = self.devs()?;
 

--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -75,12 +75,12 @@ impl BluezDev {
         self.bonded
     }
 
-    pub fn alias(&self) -> String {
-        self.alias.clone()
+    pub fn alias(&self) -> &str {
+        &self.alias
     }
 
-    pub fn address(&self) -> String {
-        self.address.clone()
+    pub fn address(&self) -> &str {
+        &self.address
     }
 
     pub fn battery(&self) -> &Option<u8> {

--- a/src/bluez/proxies.rs
+++ b/src/bluez/proxies.rs
@@ -48,6 +48,8 @@ pub trait BluezDevice {
 
     #[zbus(property, name = "RSSI")]
     fn rssi(&self) -> zbus::Result<i16>;
+
+    fn connect(&self) -> zbus::Result<()>;
 }
 
 #[proxy(

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -16,13 +16,13 @@ pub struct ConnectArgs {
     #[arg(short, long)]
     pub contains_name: Option<String>,
 
-    /// Connect to a device via its full device ALIAS.
+    /// Connect to a known device via its full device ALIAS.
     ///
     /// The ALIAS provided must be the full device ALIAS, unlike --contains-name.
     ///
     /// If this argument is not provided, then connect first initiates a scan to let users choose a device ALIAS. (interactive mode)
     ///
-    /// If this argument is provided, then connect does not initiate a scan and attempts to connect to a device via ALIAS. (non-interactive mode)
+    /// If this argument is provided, then connect does not initiate a scan and attempts to connect to a known device via ALIAS. (non-interactive mode)
     pub alias: Option<String>,
 }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,6 +1,9 @@
-use std::{error, io};
+use std::{collections::BTreeMap, error, io, thread, time::Duration};
 
 use clap::Args;
+use tabled::{builder::Builder, settings::Style};
+
+use crate::bluez::{self};
 
 #[derive(Debug, Args)]
 pub struct ConnectArgs {
@@ -26,6 +29,146 @@ pub struct ConnectArgs {
     pub alias: Option<String>,
 }
 
-pub fn connect(f: &mut impl io::Write, args: &ConnectArgs) -> Result<(), Box<dyn error::Error>> {
-    todo!()
+#[derive(Clone, Copy)]
+enum ConnectColumn {
+    Alias,
+    Address,
+    Rssi,
+}
+
+impl From<&ConnectColumn> for String {
+    fn from(value: &ConnectColumn) -> Self {
+        let str = match value {
+            ConnectColumn::Alias => "ALIAS",
+            ConnectColumn::Address => "ADDRESS",
+            ConnectColumn::Rssi => "RSSI",
+        };
+
+        str.to_string()
+    }
+}
+
+trait Listable {
+    fn get_listing_field_by_column(&self, column: &ConnectColumn) -> String;
+}
+
+impl Listable for bluez::Device {
+    fn get_listing_field_by_column(&self, column: &ConnectColumn) -> String {
+        match column {
+            ConnectColumn::Alias => self.alias().to_string(),
+            ConnectColumn::Address => self.address().to_string(),
+            ConnectColumn::Rssi => match self.rssi() {
+                Some(rssi) => rssi.to_string(),
+                None => "-".to_string(),
+            },
+        }
+    }
+}
+
+const LISTING_COLUMNS: [ConnectColumn; 3] = [
+    ConnectColumn::Alias,
+    ConnectColumn::Address,
+    ConnectColumn::Rssi,
+];
+
+pub fn connect(
+    w: &mut impl io::Write,
+    r: &mut impl io::Read,
+    args: &ConnectArgs,
+) -> Result<(), Box<dyn error::Error>> {
+    let bluez = bluez::Client::new()?;
+
+    let (alias, did_scan) = match &args.alias {
+        Some(a) => (a, false),
+        None => (
+            &{
+                // TODO: Merge this fn with bt::scan after the formatting logic is finalized. Both of these are almost identical.
+                let devices = scan_devices(&bluez, &args.duration, &args.contains_name)?;
+
+                read_device_alias(w, r, &devices)?
+            },
+            true,
+        ),
+    };
+
+    bluez.connect(alias)?;
+
+    let out_buf = format!("connected to device: {}", alias);
+    w.write_all(out_buf.as_bytes())?;
+
+    if did_scan {
+        bluez.stop_discovery()?;
+    }
+
+    Ok(())
+}
+
+fn scan_devices(
+    bluez: &bluez::Client,
+    duration: &Option<u8>,
+    contains_name: &Option<String>,
+) -> Result<Vec<bluez::Device>, Box<dyn error::Error>> {
+    bluez.start_discovery()?;
+
+    let scan_duration = u64::from(duration.unwrap_or(5));
+    thread::sleep(Duration::from_secs(scan_duration));
+
+    let scan_result = bluez.scanned_devices()?;
+    Ok(match contains_name {
+        Some(name) => scan_result
+            .into_iter()
+            .filter(|d| d.alias().contains(name))
+            .collect(),
+        None => scan_result,
+    })
+}
+
+fn read_device_alias(
+    w: &mut impl io::Write,
+    r: &mut impl io::Read,
+    devices: &[bluez::Device],
+) -> Result<String, Box<dyn error::Error>> {
+    let mut device_map: BTreeMap<usize, &bluez::Device> =
+        BTreeMap::from_iter(devices.iter().enumerate());
+
+    let prompt = [
+        &create_device_list(&device_map),
+        "\n",
+        "Select the device you wish to connect: ",
+    ]
+    .concat();
+    w.write_all(prompt.as_bytes())?;
+    w.flush()?;
+
+    let mut read_buf: Vec<u8> = Vec::with_capacity(1);
+    r.read_exact(&mut read_buf)?;
+
+    let selected_idx = String::from_utf8(read_buf)?.trim().parse::<u8>()?;
+    // WARN: Once the errors are designed, replace this unwrap call accordingly.
+    let selected_device = device_map.remove(&(selected_idx as usize)).unwrap();
+
+    Ok(selected_device.alias().to_string())
+}
+
+fn create_device_list(device_map: &BTreeMap<usize, &bluez::Device>) -> String {
+    let mut table_builder = Builder::new();
+
+    let mut columns = LISTING_COLUMNS.map(|c| String::from(&c)).to_vec();
+    columns.insert(0, "IDX".to_string());
+
+    table_builder.push_record(columns);
+
+    for (idx, dev) in device_map {
+        let mut row = LISTING_COLUMNS
+            .map(|c| dev.get_listing_field_by_column(&c))
+            .to_vec();
+        row.insert(0, format!("({})", idx));
+
+        table_builder.push_record(row);
+    }
+
+    let mut prompt = table_builder.build();
+    prompt.with(Style::blank());
+
+    prompt.to_string()
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,31 @@
+use std::{error, io};
+
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ConnectArgs {
+    /// Set the duration of the interactive scan.
+    ///
+    /// This option has no effect if the device ALIAS is provided.
+    #[arg(short, long)]
+    pub duration: Option<u8>,
+
+    /// Only show devices that contains the name <CONTAINS_NAME> during the interactive scan.
+    ///
+    /// This option has no effect if the device ALIAS is provided.
+    #[arg(short, long)]
+    pub contains_name: Option<String>,
+
+    /// Connect to a device via its full device ALIAS.
+    ///
+    /// The ALIAS provided must be the full device ALIAS, unlike --contains-name.
+    ///
+    /// If this argument is not provided, then connect first initiates a scan to let users choose a device ALIAS. (interactive mode)
+    ///
+    /// If this argument is provided, then connect does not initiate a scan and attempts to connect to a device via ALIAS. (non-interactive mode)
+    pub alias: Option<String>,
+}
+
+pub fn connect(f: &mut impl io::Write, args: &ConnectArgs) -> Result<(), Box<dyn error::Error>> {
+    todo!()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod api;
 mod bluez;
+mod connect;
 mod list_devices;
 mod scan;
 mod status;
 mod toggle;
 
+pub use connect::connect;
 pub use list_devices::list_devices;
 pub use scan::scan;
 pub use status::status;

--- a/src/list_devices.rs
+++ b/src/list_devices.rs
@@ -60,8 +60,8 @@ pub trait BtListingConverter {
 impl BtListingConverter for bluez::Device {
     fn get_listing_field_by_key(&self, value: &ListDevicesColumn) -> String {
         match value {
-            ListDevicesColumn::Alias => self.alias(),
-            ListDevicesColumn::Address => self.address(),
+            ListDevicesColumn::Alias => self.alias().to_string(),
+            ListDevicesColumn::Address => self.address().to_string(),
             ListDevicesColumn::Connected => self.connected().to_string(),
             ListDevicesColumn::Trusted => self.trusted().to_string(),
             ListDevicesColumn::Bonded => self.bonded().to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,14 @@ fn run() -> Result<(), Box<dyn error::Error>> {
     println!("{:?}", args);
 
     let mut stdout = io::stdout();
+    let mut stdin = io::stdin();
 
     if let Some(subcommand) = args.command {
         match subcommand {
             BtCommand::Status => bt::status(&mut stdout),
             BtCommand::Toggle => bt::toggle(&mut stdout),
             BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
-            BtCommand::Connect { args } => bt::connect(&mut stdout, &args),
+            BtCommand::Connect { args } => bt::connect(&mut stdout, &mut stdin, &args),
             BtCommand::Disconnect { force } => todo!(),
             BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             BtCommand::Status => bt::status(&mut stdout),
             BtCommand::Toggle => bt::toggle(&mut stdout),
             BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
-            BtCommand::Connect { args } => todo!(),
+            BtCommand::Connect { args } => bt::connect(&mut stdout, &args),
             BtCommand::Disconnect { force } => todo!(),
             BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),
         }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,4 +1,4 @@
-use std::{error, io};
+use std::{error, io, thread, time::Duration};
 
 use clap::Args;
 use tabled::{builder::Builder, settings::Style};
@@ -66,9 +66,6 @@ impl From<&ScanColumn> for String {
 }
 
 pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error::Error>> {
-    let bluez = bluez::Client::new()?;
-    let scan_result = bluez.scan(&args.duration)?;
-
     let (out_format, listing_keys) = match (&args.columns, &args.values) {
         (None, None) => (ScanOutput::Pretty, &DEFAULT_LISTING_KEYS.to_vec()),
         (None, Some(v)) => (
@@ -89,7 +86,14 @@ pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error
         ),
     };
 
-    let listing = scan_result.iter().map(|d| {
+    let bluez = bluez::Client::new()?;
+
+    bluez.start_discovery()?;
+    thread::sleep(Duration::from_secs(u64::from(args.duration)));
+
+    let scanned_devices = bluez.scanned_devices()?;
+
+    let listing = scanned_devices.iter().map(|d| {
         listing_keys
             .iter()
             .map(|k| d.get_listing_field_by_column(k))
@@ -103,8 +107,11 @@ pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Box<dyn error
 
     f.write_all(out_buf.as_bytes())?;
 
+    bluez.stop_discovery()?;
+
     Ok(())
 }
+
 pub fn create_pretty_out(
     listing: impl Iterator<Item = Vec<String>>,
     columns: &[ScanColumn],

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -46,8 +46,8 @@ pub trait Listable {
 impl Listable for bluez::Device {
     fn get_listing_field_by_column(&self, value: &ScanColumn) -> String {
         match value {
-            ScanColumn::Alias => self.alias(),
-            ScanColumn::Address => self.address(),
+            ScanColumn::Alias => self.alias().to_string(),
+            ScanColumn::Address => self.address().to_string(),
             ScanColumn::Rssi => self.rssi().unwrap_or(0).to_string(),
         }
     }


### PR DESCRIPTION
`bt connect` (or `bt c` with alias) is implemented to allow users to connect to their Bluetooth devices in a more convenient way than `bluetoothctl` offers.

For convenience, it has two modes:

- A non-interactive mode for cases where the device alias is known and users just want to connect them directly.

- An interactive mode for cases where the device is not known or it's alias is not convenient to type.
In this mode, a device scan is initiated and the results are shown to the user via a pretty format, similar to other `bt` commands.

Once the alias is known via one of the methods above, `bt connect` tries to establish a connection through `org.bluez.Device1` interface of the device.

## Other Changes

The most notable change in this PR is probably the removal of `Bluez::scan()` method. Here is a detailed breakdown of why:

While the initial scan functionality of Bluez client worked for `bt scan`, a design issue was noticed during the `bt connect` implementation:

- The created device object paths are flushed when `Bluez::stop_discovery()` is called. However, it is not known exactly when they are removed. The documentation says that it happens within 3 minutes, which is not specific enough.

- This creates a non-deterministic behavior during `bt connect` implementation because during the interactive scan, `bt connect` is designed to wait for the user input to proceed. Since users can choose whenever they want, the selected device should not be flushed before the interactive scan.

In order to fix this behavior, the higher-level `Bluez::scan()` is removed completely.
Instead, the caller now handles when to start and stop the device discovery.

## Usages

```bash
# Provide the known device's ALIAS to directly connect to it.
$ bt connect <KNOWN_DEVICE_ALIAS>

# If the ALIAS is not known, `bt connect` does an interactive scan to determine the device.
$ bt connect
# IDX   ALIAS               ADDRESS             RSSI
# (0)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -94
# (1)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -50
# (2)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -68
# (3)   dummy-device        XX:XX:XX:XX:XX:XX   -80
# Select the device you wish to connect:

# Use --duration to set the scan duration (seconds).
# By default, the scan duration is 5 seconds.
$ bt connect --duration 10
# IDX   ALIAS               ADDRESS             RSSI
# (0)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -94
# (1)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -50
# (2)   XX-XX-XX-XX-XX-XX   XX:XX:XX:XX:XX:XX   -68
# (3)   dummy-device        XX:XX:XX:XX:XX:XX   -80
# Select the device you wish to connect:

# Use `--contains-name` to filter the scanned devices
# by their ALIAS'es.
# This is not an exact match, and does not support glob patterns 
# for now.
$ bt connect --contains-name dummy
# IDX   ALIAS               ADDRESS             RSSI
# (0)   dummy-device        XX:XX:XX:XX:XX:XX   -80
# Select the device you wish to connect:
```
 

