### PR TITLE
feat(api): Update `bt disconnect` API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -39,11 +39,19 @@ pub enum BtCommand {
         args: ConnectArgs,
     },
 
-    /// Disconnect from an available device.
+    /// Disconnect from the connected device(s).
     #[clap(visible_alias = "d")]
     Disconnect {
-        /// Remove the device from the known devices list.
+        /// Remove the device(s) from the known devices list.
         #[arg(short, long, default_value_t = false)]
         force: bool,
+
+        /// Disconnect by specifying the full ALIAS of device(s).
+        ///
+        /// If this argument is not provided, then disconnect first shows the list of connected devices to let users choose. (interactive mode)
+        ///
+        /// If this argument is provided, then disconnect does not show the list. (non-interactive mode)
+        #[arg(value_name = "ALIAS", value_delimiter = ' ', num_args = 0.., default_value = None)]
+        aliases: Option<Vec<String>>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             BtCommand::Toggle => bt::toggle(&mut stdout),
             BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
             BtCommand::Connect { args } => bt::connect(&mut stdout, &mut stdin, &args),
-            BtCommand::Disconnect { force } => todo!(),
+            BtCommand::Disconnect { force, aliases } => todo!(),
             BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),
         }
     } else {


### PR DESCRIPTION
A new argument `[ALIAS]...` is added to `bt disconnect` to allow users to directly disconnect without selecting the device aliases from the known device list.

This argument is provided to have a non-interactive disconnect flow.