### PR TITLE
fix(connect): Block idx read in interactive mode

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -73,7 +73,7 @@ const LISTING_COLUMNS: [ConnectColumn; 3] = [
 
 pub fn connect(
     w: &mut impl io::Write,
-    r: &mut impl io::Read,
+    r: &mut impl io::BufRead,
     args: &ConnectArgs,
 ) -> Result<(), Box<dyn error::Error>> {
     let bluez = bluez::Client::new()?;
@@ -125,7 +125,7 @@ fn scan_devices(
 
 fn read_device_alias(
     w: &mut impl io::Write,
-    r: &mut impl io::Read,
+    r: &mut impl io::BufRead,
     devices: &[bluez::Device],
 ) -> Result<String, Box<dyn error::Error>> {
     let mut device_map: BTreeMap<usize, &bluez::Device> =
@@ -140,10 +140,10 @@ fn read_device_alias(
     w.write_all(prompt.as_bytes())?;
     w.flush()?;
 
-    let mut read_buf: Vec<u8> = Vec::with_capacity(1);
-    r.read_exact(&mut read_buf)?;
+    let mut read_buf = String::with_capacity(1);
+    r.read_line(&mut read_buf)?;
 
-    let selected_idx = String::from_utf8(read_buf)?.trim().parse::<u8>()?;
+    let selected_idx = read_buf.trim().parse::<u8>()?;
     // WARN: Once the errors are designed, replace this unwrap call accordingly.
     let selected_device = device_map.remove(&(selected_idx as usize)).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,17 @@ fn run() -> Result<(), Box<dyn error::Error>> {
     println!("{:?}", args);
 
     let mut stdout = io::stdout();
-    let mut stdin = io::stdin();
+    let stdin = io::stdin();
 
     if let Some(subcommand) = args.command {
         match subcommand {
             BtCommand::Status => bt::status(&mut stdout),
             BtCommand::Toggle => bt::toggle(&mut stdout),
             BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
-            BtCommand::Connect { args } => bt::connect(&mut stdout, &mut stdin, &args),
+            BtCommand::Connect { args } => {
+                let mut locked_stdin = stdin.lock();
+                bt::connect(&mut stdout, &mut locked_stdin, &args)
+            }
             BtCommand::Disconnect { force, aliases } => {
                 let mut locked_stdin = stdin.lock();
                 bt::disconnect(&mut stdout, &mut locked_stdin, &force, &aliases)


### PR DESCRIPTION
At first, the user input was read by using `io::Read::read_exact`.

However, that method does not wait and just reads `buf.len()` bytes from the reader.

That is why, `io::BufRead::read_line` is used instead of `read_exact` to wait until newline appears on the reader, which does when users enter their selection.