### PR TITLE
feat(errors): Add custom error handling for `bt` commands

### DIFF
--- a/src/bluez/mod.rs
+++ b/src/bluez/mod.rs
@@ -2,3 +2,4 @@ mod client;
 mod proxies;
 
 pub use client::{Bluez as Client, BluezDev as Device};
+pub use zbus::Error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,39 +3,43 @@ use std::{error, io, process::ExitCode};
 use bt::api::{BtCommand, Cli};
 use clap::Parser;
 
+const PROGRAM: &str = "bt";
+
 fn main() -> ExitCode {
     match run() {
         Ok(_) => ExitCode::SUCCESS,
-        Err(_) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("{PROGRAM}: {}", e);
+
+            ExitCode::FAILURE
+        }
     }
 }
 
 fn run() -> Result<(), Box<dyn error::Error>> {
     let args = Cli::parse();
 
-    println!("{:?}", args);
-
     let mut stdout = io::stdout();
     let stdin = io::stdin();
 
     if let Some(subcommand) = args.command {
         match subcommand {
-            BtCommand::Status => bt::status(&mut stdout),
-            BtCommand::Toggle => bt::toggle(&mut stdout),
-            BtCommand::Scan { args } => bt::scan(&mut stdout, &args),
+            BtCommand::Status => bt::status(&mut stdout)?,
+            BtCommand::Toggle => bt::toggle(&mut stdout)?,
+            BtCommand::Scan { args } => bt::scan(&mut stdout, &args)?,
             BtCommand::Connect { args } => {
                 let mut locked_stdin = stdin.lock();
-                bt::connect(&mut stdout, &mut locked_stdin, &args)
+                bt::connect(&mut stdout, &mut locked_stdin, &args)?
             }
             BtCommand::Disconnect { force, aliases } => {
                 let mut locked_stdin = stdin.lock();
-                bt::disconnect(&mut stdout, &mut locked_stdin, &force, &aliases)
+                bt::disconnect(&mut stdout, &mut locked_stdin, &force, &aliases)?
             }
-            BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args),
+            BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args)?,
         }
     } else {
-        bt::status(&mut stdout)
-    }?;
+        bt::status(&mut stdout)?
+    };
 
     Ok(())
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,12 +1,45 @@
-use std::{error, io};
+use std::{error, fmt, io};
 
 use crate::bluez;
 
-pub fn status(f: &mut impl io::Write) -> Result<(), Box<dyn error::Error>> {
-    let bluez = bluez::Client::new()?;
+#[derive(Debug)]
+pub enum Error {
+    PowerState(bluez::Error),
+    ConnectedDevices(bluez::Error),
+    DBusClient(bluez::Error),
+    Io(io::Error),
+}
 
-    let power_state = bluez.power_state()?;
-    let connected_devs = bluez.connected_devs()?;
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Error::PowerState(error) => {
+                write!(f, "unable to get device power state: {}", error)
+            }
+            Error::ConnectedDevices(error) => {
+                write!(f, "unable to get connected devices: {}", error)
+            }
+            Error::DBusClient(error) => {
+                write!(f, "unable to establish a D-Bus connection: {}", error)
+            }
+            Error::Io(error) => write!(f, "io error: {}", error),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+pub fn status(f: &mut impl io::Write) -> Result<(), Error> {
+    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
+
+    let power_state = bluez.power_state().map_err(Error::PowerState)?;
+    let connected_devs = bluez.connected_devs().map_err(Error::ConnectedDevices)?;
 
     let mut buf = [
         "bluetooth: ",

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,10 +1,39 @@
-use std::{error, io};
+use std::{error, fmt, io};
 
 use crate::bluez;
 
-pub fn toggle(f: &mut impl io::Write) -> Result<(), Box<dyn error::Error>> {
-    let bluez = bluez::Client::new()?;
-    let toggled_power_state = bluez.toggle_power_state()?;
+#[derive(Debug)]
+pub enum Error {
+    PowerState(bluez::Error),
+    DBusClient(bluez::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Error::PowerState(error) => {
+                write!(f, "unable to toggle device power state: {}", error)
+            }
+            Error::DBusClient(error) => {
+                write!(f, "unable to establish a D-Bus connection: {}", error)
+            }
+            Error::Io(error) => write!(f, "io error: {}", error),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+pub fn toggle(f: &mut impl io::Write) -> Result<(), Error> {
+    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
+    let toggled_power_state = bluez.toggle_power_state().map_err(Error::PowerState)?;
 
     let buf = format!("bluetooth: {}", toggled_power_state);
     f.write_all(buf.as_bytes())?;


### PR DESCRIPTION
Custom error enums are added for all subcommands to notify users with helpful diagnostics. 
The errors are printed through `stderr`, and ecode `1` is used to exit with a non-zero value as expected.
