### PR TITLE
feat(bluez): Move Bluez init to bin root

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -121,18 +121,17 @@ const LISTING_COLUMNS: [ConnectColumn; 3] = [
 ];
 
 pub fn connect(
+    bluez: &bluez::Client,
     w: &mut impl io::Write,
     r: &mut impl io::BufRead,
     args: &ConnectArgs,
 ) -> Result<(), Error> {
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
-
     let (alias, did_scan) = match &args.alias {
         Some(a) => (a, false),
         None => (
             &{
                 // TODO: Merge this fn with bt::scan after the formatting logic is finalized. Both of these are almost identical.
-                let devices = scan_devices(&bluez, &args.duration, &args.contains_name)?;
+                let devices = scan_devices(bluez, &args.duration, &args.contains_name)?;
 
                 read_device_alias(w, r, &devices)?
             },

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -80,16 +80,15 @@ impl Listable for bluez::Device {
 }
 
 pub fn disconnect(
+    bluez: &bluez::Client,
     w: &mut impl io::Write,
     r: &mut impl io::BufRead,
     force: &bool,
     aliases: &Option<Vec<String>>,
 ) -> Result<(), Error> {
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
-
     let aliases = match aliases.as_ref() {
         Some(aliases) => aliases,
-        None => &{ get_aliases_from_user(w, r, &bluez)? },
+        None => &{ get_aliases_from_user(w, r, bluez)? },
     };
 
     for alias in aliases {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod scan;
 mod status;
 mod toggle;
 
+pub use bluez::Client as BluezClient;
 pub use connect::connect;
 pub use disconnect::disconnect;
 pub use list_devices::list_devices;

--- a/src/list_devices.rs
+++ b/src/list_devices.rs
@@ -127,7 +127,11 @@ impl From<&ListDevicesColumn> for String {
     }
 }
 
-pub fn list_devices(f: &mut impl io::Write, args: &ListDevicesArgs) -> Result<(), Error> {
+pub fn list_devices(
+    bluez: &crate::BluezClient,
+    f: &mut impl io::Write,
+    args: &ListDevicesArgs,
+) -> Result<(), Error> {
     let (out_format, user_listing_keys) = match (&args.columns, &args.values) {
         (None, None) => (ListDevicesOutput::Pretty, None),
         (None, values) => (ListDevicesOutput::Terse, values.as_ref()),
@@ -139,7 +143,6 @@ pub fn list_devices(f: &mut impl io::Write, args: &ListDevicesArgs) -> Result<()
         None => &DEFAULT_LISTING_KEYS.to_vec(),
     };
 
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
     let devs = bluez.devs().map_err(Error::KnownDevices)?;
 
     let listing = devs.iter().filter_map(|dev| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), Box<dyn error::Error>> {
+    let bluez = bt::BluezClient::new()?;
+
     let args = Cli::parse();
 
     let mut stdout = io::stdout();
@@ -24,21 +26,21 @@ fn run() -> Result<(), Box<dyn error::Error>> {
 
     if let Some(subcommand) = args.command {
         match subcommand {
-            BtCommand::Status => bt::status(&mut stdout)?,
-            BtCommand::Toggle => bt::toggle(&mut stdout)?,
-            BtCommand::Scan { args } => bt::scan(&mut stdout, &args)?,
+            BtCommand::Status => bt::status(&bluez, &mut stdout)?,
+            BtCommand::Toggle => bt::toggle(&bluez, &mut stdout)?,
+            BtCommand::Scan { args } => bt::scan(&bluez, &mut stdout, &args)?,
             BtCommand::Connect { args } => {
-                let mut locked_stdin = stdin.lock();
-                bt::connect(&mut stdout, &mut locked_stdin, &args)?
+                let mut stdin_handle = stdin.lock();
+                bt::connect(&bluez, &mut stdout, &mut stdin_handle, &args)?
             }
             BtCommand::Disconnect { force, aliases } => {
-                let mut locked_stdin = stdin.lock();
-                bt::disconnect(&mut stdout, &mut locked_stdin, &force, &aliases)?
+                let mut stdin_handle = stdin.lock();
+                bt::disconnect(&bluez, &mut stdout, &mut stdin_handle, &force, &aliases)?
             }
-            BtCommand::ListDevices { args } => bt::list_devices(&mut stdout, &args)?,
+            BtCommand::ListDevices { args } => bt::list_devices(&bluez, &mut stdout, &args)?,
         }
     } else {
-        bt::status(&mut stdout)?
+        bt::status(&bluez, &mut stdout)?
     };
 
     Ok(())

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -99,7 +99,11 @@ impl From<&ScanColumn> for String {
     }
 }
 
-pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Error> {
+pub fn scan(
+    bluez: &crate::BluezClient,
+    f: &mut impl io::Write,
+    args: &ScanArgs,
+) -> Result<(), Error> {
     let (out_format, listing_keys) = match (&args.columns, &args.values) {
         (None, None) => (ScanOutput::Pretty, &DEFAULT_LISTING_KEYS.to_vec()),
         (None, Some(v)) => (
@@ -119,8 +123,6 @@ pub fn scan(f: &mut impl io::Write, args: &ScanArgs) -> Result<(), Error> {
             },
         ),
     };
-
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
 
     bluez.start_discovery().map_err(Error::Start)?;
     thread::sleep(Duration::from_secs(u64::from(args.duration)));

--- a/src/status.rs
+++ b/src/status.rs
@@ -35,9 +35,7 @@ impl From<io::Error> for Error {
     }
 }
 
-pub fn status(f: &mut impl io::Write) -> Result<(), Error> {
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
-
+pub fn status(bluez: &crate::BluezClient, f: &mut impl io::Write) -> Result<(), Error> {
     let power_state = bluez.power_state().map_err(Error::PowerState)?;
     let connected_devs = bluez.connected_devs().map_err(Error::ConnectedDevices)?;
 

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -31,8 +31,7 @@ impl From<io::Error> for Error {
     }
 }
 
-pub fn toggle(f: &mut impl io::Write) -> Result<(), Error> {
-    let bluez = bluez::Client::new().map_err(Error::DBusClient)?;
+pub fn toggle(bluez: &crate::BluezClient, f: &mut impl io::Write) -> Result<(), Error> {
     let toggled_power_state = bluez.toggle_power_state().map_err(Error::PowerState)?;
 
     let buf = format!("bluetooth: {}", toggled_power_state);


### PR DESCRIPTION
Instead of initializing Bluez inside the subcommand modules, it is initialized inside the bin root.

This is done to make the lib crate more testable and extensible.

For now, the `BluezClient` type is left as a concrete type, but it will be converted into a trait later on to satisfy the goal above.