### PR TITLE
feat(bluez): Mv DBusClientError under bluez module

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,7 +7,6 @@ use crate::bluez::{self};
 
 #[derive(Debug)]
 pub enum Error {
-    DBusClient(bluez::Error),
     StartDiscovery(bluez::Error),
     DiscoveredDevices(bluez::Error),
     StopDiscovery(bluez::Error),
@@ -19,9 +18,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a D-Bus connection: {}", error)
-            }
             Error::StartDiscovery(error) => {
                 write!(f, "unable to start device discovery: {}", error)
             }

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -6,7 +6,6 @@ use crate::bluez;
 
 #[derive(Debug)]
 pub enum Error {
-    DBusClient(bluez::Error),
     Disconnect(bluez::Error),
     Remove(bluez::Error),
     InvalidAlias,
@@ -17,9 +16,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a D-Bus connection: {}", error)
-            }
             Error::Disconnect(error) => write!(f, "unable to disconnect: {}", error),
             Error::Remove(error) => write!(f, "unable to remove: {}", error),
             Error::InvalidAlias => write!(f, "the provided alias is invalid"),

--- a/src/list_devices.rs
+++ b/src/list_devices.rs
@@ -8,7 +8,6 @@ use crate::bluez;
 
 #[derive(Debug)]
 pub enum Error {
-    DBusClient(bluez::Error),
     KnownDevices(bluez::Error),
     Io(io::Error),
 }
@@ -16,9 +15,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a D-Bus connection: {}", error)
-            }
             Error::KnownDevices(error) => {
                 write!(f, "unable to get known bluetooth devices: {}", error)
             }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -8,7 +8,6 @@ use crate::bluez;
 
 #[derive(Debug)]
 pub enum Error {
-    DBusClient(bluez::Error),
     Start(bluez::Error),
     Stop(bluez::Error),
     DiscoveredDevices(bluez::Error),
@@ -18,9 +17,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a DBus connection: {}", error)
-            }
             Error::Start(error) => write!(f, "unable to start device discovery: {}", error),
             Error::Stop(error) => write!(f, "unable to stop device discovery: {}", error),
             Error::DiscoveredDevices(error) => {

--- a/src/status.rs
+++ b/src/status.rs
@@ -6,7 +6,6 @@ use crate::bluez;
 pub enum Error {
     PowerState(bluez::Error),
     ConnectedDevices(bluez::Error),
-    DBusClient(bluez::Error),
     Io(io::Error),
 }
 
@@ -18,9 +17,6 @@ impl fmt::Display for Error {
             }
             Error::ConnectedDevices(error) => {
                 write!(f, "unable to get connected devices: {}", error)
-            }
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a D-Bus connection: {}", error)
             }
             Error::Io(error) => write!(f, "io error: {}", error),
         }

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -5,7 +5,6 @@ use crate::bluez;
 #[derive(Debug)]
 pub enum Error {
     PowerState(bluez::Error),
-    DBusClient(bluez::Error),
     Io(io::Error),
 }
 
@@ -14,9 +13,6 @@ impl fmt::Display for Error {
         match &self {
             Error::PowerState(error) => {
                 write!(f, "unable to toggle device power state: {}", error)
-            }
-            Error::DBusClient(error) => {
-                write!(f, "unable to establish a D-Bus connection: {}", error)
             }
             Error::Io(error) => write!(f, "io error: {}", error),
         }


### PR DESCRIPTION
This is done to:

- Have the same error handling logic as subcommand modules during the initialization of `BluezClient` in bin crate root.
- Remove the duplicate `DBusClient` error variants in subcommand modules.

Since the `Error` will be only used during the initialization phase, a simple `From<zbus::Error>` impl is done to construct the error.