### PR TITLE
feat(disconn): Exit early if there are no conn devs

### DIFF
--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -11,6 +11,7 @@ pub enum Error {
     Remove(bluez::Error),
     InvalidAlias,
     ConnectedDevices(bluez::Error),
+    NoConnectedDevices,
     Io(io::Error),
 }
 
@@ -24,6 +25,7 @@ impl fmt::Display for Error {
                 write!(f, "unable to get connected devices: {}", error)
             }
             Error::Io(error) => write!(f, "io error: {}", error),
+            Error::NoConnectedDevices => write!(f, "there are no connected devices to disconnect"),
         }
     }
 }
@@ -116,6 +118,9 @@ fn get_aliases_from_user(
     devices: Vec<bluez::Device>,
 ) -> Result<Vec<String>, Error> {
     let dev_len = devices.len();
+    if dev_len == 0 {
+        return Err(Error::NoConnectedDevices);
+    }
 
     let mut device_map = BTreeMap::from_iter(devices.into_iter().enumerate());
     let devices = device_map


### PR DESCRIPTION
During the interactive mode of `disconnect`, it is noticed that if there are no connected devices, the list is shown as empty and users are still asked to choose a device.

This does not happen in non-interactive mode, in that case the Bluez client returns the appropriate error `bluez::Error::InterfaceNotFound`.

Therefore, in order to prevent this incorrect state during the interactive mode, a new error `disconnect::Error::NoConnectedDevices` is added.