### PR TITLE
feat(bluez): Update bluez module to prepare for tests

### DIFF
--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -114,12 +114,12 @@ impl From<zbus::Error> for Error {
     }
 }
 
-pub struct Bluez {
+pub struct BluezDBusClient {
     connection: Connection,
     adapter_proxy: BluezAdapterProxy<'static>,
 }
 
-impl Bluez {
+impl BluezDBusClient {
     pub fn new() -> Result<Self, Error> {
         let connection = Connection::system()?;
         let adapter_proxy = BluezAdapterProxy::new(&connection)?;
@@ -288,6 +288,153 @@ impl Bluez {
             dev_proxy.disconnect()
         } else {
             Err(zbus::Error::InterfaceNotFound)
+        }
+    }
+}
+
+pub struct BluezTestClient {
+    erred_method_name: Option<String>,
+    err: zbus::Error,
+}
+
+impl BluezTestClient {
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self {
+            erred_method_name: None,
+            err: zbus::Error::InvalidReply,
+        })
+    }
+
+    pub fn set_erred_method_name(&mut self, name: String) {
+        self.erred_method_name = Some(name);
+    }
+
+    pub fn power_state(&self) -> zbus::Result<BluezPowerState> {
+        let err_key = String::from("power_state");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(BluezPowerState::On),
+        }
+    }
+
+    pub fn toggle_power_state(&self) -> zbus::Result<BluezPowerState> {
+        let err_key = String::from("toggle_power_state");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(BluezPowerState::On),
+        }
+    }
+
+    pub fn devices(&self) -> zbus::Result<Vec<BluezDev>> {
+        let err_key = String::from("devices");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => {
+                let device = BluezDev {
+                    alias: String::from("test_dev"),
+                    address: String::from("XX:XX:XX:XX:XX:XX"),
+                    connected: true,
+                    paired: true,
+                    trusted: true,
+                    bonded: false,
+                    battery: Some(50),
+                    rssi: None,
+                };
+
+                Ok(vec![device])
+            }
+        }
+    }
+
+    pub fn connect(&self, _: &str) -> zbus::Result<()> {
+        let err_key = String::from("connect");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn connected_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+        let err_key = String::from("connected_devices");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => {
+                let device = BluezDev {
+                    alias: String::from("test_dev"),
+                    address: String::from("XX:XX:XX:XX:XX:XX"),
+                    connected: true,
+                    paired: true,
+                    trusted: true,
+                    bonded: false,
+                    battery: Some(50),
+                    rssi: None,
+                };
+
+                Ok(vec![device])
+            }
+        }
+    }
+
+    pub fn start_discovery(&self) -> zbus::Result<()> {
+        let err_key = String::from("start_discovery");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn stop_discovery(&self) -> zbus::Result<()> {
+        let err_key = String::from("stop_discovery");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn scanned_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+        let err_key = String::from("scanned_devices");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => {
+                let device = BluezDev {
+                    alias: String::from("test_dev"),
+                    address: String::from("XX:XX:XX:XX:XX:XX"),
+                    connected: true,
+                    paired: true,
+                    trusted: true,
+                    bonded: false,
+                    battery: None,
+                    rssi: Some(50),
+                };
+
+                Ok(vec![device])
+            }
+        }
+    }
+
+    pub fn remove(&self, _: &str) -> zbus::Result<()> {
+        let err_key = String::from("remove");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn disconnect(&self, _: &str) -> zbus::Result<()> {
+        let err_key = String::from("disconnect");
+
+        match &self.erred_method_name {
+            Some(v) if v == &err_key => Err(self.err.clone()),
+            _ => Ok(()),
         }
     }
 }

--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -180,7 +180,7 @@ impl BluezDBusClient {
         Ok(new_state)
     }
 
-    pub fn devs(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn devices(&self) -> zbus::Result<Vec<BluezDev>> {
         let dev_object_iter = self.dev_object_iter()?;
 
         Ok(dev_object_iter
@@ -230,8 +230,8 @@ impl BluezDBusClient {
         Err(zbus::Error::InterfaceNotFound)
     }
 
-    pub fn connected_devs(&self) -> zbus::Result<Vec<BluezDev>> {
-        let devs = self.devs()?;
+    pub fn connected_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+        let devs = self.devices()?;
 
         Ok(devs.into_iter().filter(|d| d.connected).collect())
     }
@@ -245,7 +245,7 @@ impl BluezDBusClient {
     }
 
     pub fn scanned_devices(&self) -> zbus::Result<Vec<BluezDev>> {
-        let devs = self.devs()?;
+        let devs = self.devices()?;
         Ok(devs.into_iter().filter(|d| d.rssi.is_some()).collect())
     }
 

--- a/src/bluez/mod.rs
+++ b/src/bluez/mod.rs
@@ -1,5 +1,12 @@
 mod client;
 mod proxies;
 
-pub use client::{Bluez as Client, BluezDev as Device};
+pub use client::BluezDev as Device;
+
+#[cfg(not(test))]
+pub use client::BluezDBusClient as Client;
+
+#[cfg(test)]
+pub use client::BluezTestClient as Client;
+
 pub use zbus::Error;

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -119,7 +119,7 @@ const DEFAULT_LISTING_COLUMNS: [ConnectColumn; 4] = [
 ];
 
 pub fn connect(
-    bluez: &bluez::Client,
+    bluez: &crate::BluezClient,
     w: &mut impl io::Write,
     r: &mut impl io::BufRead,
     args: &ConnectArgs,
@@ -149,7 +149,7 @@ pub fn connect(
 }
 
 fn scan_devices(
-    bluez: &bluez::Client,
+    bluez: &crate::BluezClient,
     duration: &Option<u8>,
     contains_name: &Option<String>,
 ) -> Result<Vec<bluez::Device>, Error> {

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -89,7 +89,7 @@ pub fn disconnect(
     let aliases = match aliases.as_ref() {
         Some(aliases) => aliases,
         None => &{
-            let devices = bluez.connected_devs().map_err(Error::ConnectedDevices)?;
+            let devices = bluez.connected_devices().map_err(Error::ConnectedDevices)?;
 
             get_aliases_from_user(w, r, devices)?
         },

--- a/src/disconnect.rs
+++ b/src/disconnect.rs
@@ -80,7 +80,7 @@ impl TableFormattable<DisconnectColumn> for (&usize, &bluez::Device) {
 }
 
 pub fn disconnect(
-    bluez: &bluez::Client,
+    bluez: &crate::BluezClient,
     w: &mut impl io::Write,
     r: &mut impl io::BufRead,
     force: &bool,

--- a/src/list_devices.rs
+++ b/src/list_devices.rs
@@ -138,7 +138,7 @@ pub fn list_devices(
         None => &DEFAULT_LISTING_COLUMNS.to_vec(),
     };
 
-    let devices = bluez.devs().map_err(Error::KnownDevices)?;
+    let devices = bluez.devices().map_err(Error::KnownDevices)?;
     let devices = devices.into_iter().filter(|d| match &args.status {
         Some(s) => d.filter_cell_value_by_status(s),
         None => true,

--- a/src/status.rs
+++ b/src/status.rs
@@ -33,7 +33,7 @@ impl From<io::Error> for Error {
 
 pub fn status(bluez: &crate::BluezClient, f: &mut impl io::Write) -> Result<(), Error> {
     let power_state = bluez.power_state().map_err(Error::PowerState)?;
-    let connected_devs = bluez.connected_devs().map_err(Error::ConnectedDevices)?;
+    let connected_devs = bluez.connected_devices().map_err(Error::ConnectedDevices)?;
 
     let mut buf = [
         "bluetooth: ",

--- a/src/status.rs
+++ b/src/status.rs
@@ -55,3 +55,30 @@ pub fn status(bluez: &crate::BluezClient, f: &mut impl io::Write) -> Result<(), 
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn it_should_write_bluetooth_status() {
+        let bluez = crate::BluezClient::new().unwrap();
+        let mut out_buf = Cursor::new(vec![]);
+
+        status(&bluez, &mut out_buf).unwrap();
+
+        let connected_device = &bluez.connected_devices().unwrap()[0];
+        let expected = format!(
+            "bluetooth: enabled\nconnected devices: \n{}/{} (batt: %{})",
+            connected_device.alias(),
+            connected_device.address(),
+            connected_device.battery().unwrap()
+        );
+
+        let result = String::from_utf8(out_buf.into_inner()).unwrap();
+
+        assert_eq!(expected, result)
+    }
+}


### PR DESCRIPTION
Up until this point, all of the subcommands were using the "real" Bluez DBus client.

Since the functionalities need to be tested, the "real" Bluez DBus client needs to be swapped with a different implementation for the tests.

The usual way of doing this in other languages is to design the subcommands around a single Bluez client interface, and mock the client in the tests.

Whilst this is applicable in some cases, Rust's type system is so strict, therefore this would require a change in the actual code to use dynamic dispatch (e.g. `Box<impl Client>`), just to make the code testable.

Instead of introducing abstractions just for testing purposes, a new Bluez test client struct `BluezTestClient` is added in `bluez` module.

To use the struct in tests, the client export is updated to export `BluezTestClient` for tests and `BluezDBusClient` for the actual flow.

To illustrate the usage of the `BluezTestClient`, a basic test is added to `bt::status`.