### PR TITLE
chore(cfg): Disable dead_code for BluezDBusClient

### DIFF
--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, reason = "cfg test/not(test) for BluezDBusClient")]
+
 use std::{error, fmt};
 
 use zbus::{


### PR DESCRIPTION
Since the client impl is swapped for test and no test compilation, the noise coming from clippy is disabled.