### PR TITLE
docs(status): Add doc comments for `status` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ mod scan;
 mod status;
 mod toggle;
 
-pub use bluez::Client as BluezClient;
+pub use bluez::{Client as BluezClient, Error as BluezError};
 pub use connect::connect;
 pub use disconnect::disconnect;
 pub use list_devices::list_devices;
 pub use scan::scan;
-pub use status::status;
+pub use status::{Error as StatusError, status};
 pub use toggle::toggle;

--- a/src/status.rs
+++ b/src/status.rs
@@ -2,10 +2,26 @@ use std::{error, fmt, io};
 
 use crate::bluez;
 
+/// Defines error variants that may be returned from a [`status`] call.
+///
+/// [`status`]: crate::status
 #[derive(Debug)]
 pub enum Error {
+    /// Happens when the power state of the Bluetooth adapter could not be read.
+    /// It holds the underlying [`bluez::Error`] error.
+    ///
+    /// [`bluez::Error`]: crate::bluez::Error
     PowerState(bluez::Error),
+
+    /// Happens when the connected Bluetooth devices could not be read.
+    /// It holds the underlying DBus error.
     ConnectedDevices(bluez::Error),
+
+    /// Happens when the result of [`status`] could not be written to the given buffer.
+    /// It holds the underlying [`io::Error`].
+    ///
+    /// [`status`]: crate::status
+    /// [`io::Error`]: std::io::Error
     Io(io::Error),
 }
 
@@ -31,6 +47,70 @@ impl From<io::Error> for Error {
     }
 }
 
+/// Provides the Bluetooth adapter status and connected Device-MAC address pairs by using a [`BluezClient`].
+///
+/// The Bluetooth adapter status and Device-MAC address pairs are written to the provided [`io::Write`].
+///
+/// The format of the WiFi status depends on [`BluezClient`].
+///
+/// The format of the Device-MAC address pairs is like below:
+///
+/// ```txt
+/// connected devices:
+/// Dev1/Addr1 (batt: Batt1%)
+/// Dev1/Addr2 (batt: batt2%)
+/// ...
+/// DevN/AddrN (batt: battN%)
+/// ```
+///
+/// # Panics
+///
+/// This function panics when the battery percentage of a connected device is not known.
+/// [`status`] assumes that all connected devices have their battery percentages and [`BluezClient`] is able to provide those.
+///
+/// # Errors
+///
+/// This function can return all variants of [`StatusError`] based on given conditions. For more details, please see the error documentation.
+///
+/// [`BluezClient`]: crate::BluezClient
+/// [`io::Write`]: std::io::Write
+/// [`StatusError`]: crate::StatusError
+/// [`status`]: crate::status
+///
+/// # Examples
+///
+/// Here is a basic [`status`] call. The output assertion is done to show the format of the success result. The actual output will contain the real connected device aliases and their MAC addresses.
+///
+/// ```no_run
+/// use std::io::Cursor;
+/// use bt::{status, BluezClient};
+///
+/// let bluez_client = BluezClient::new().unwrap();
+/// let mut output = Cursor::new(vec![]);
+///
+/// let status_result = status(&bluez_client, &mut output);
+///
+/// assert!(status_result.is_ok());
+/// let status_str = String::from_utf8(output.into_inner()).unwrap();
+/// assert_eq!(status_output, "bluetooth: enabled\nconnected devices:\nDev1/Addr1\nDev2/Addr2");
+///```
+///
+/// Here is an error case. The example triggers an [`io::Error`] by passing an array as a buffer, instead of a growable buffer.
+///
+/// ```no_run
+/// use std::io::Cursor;
+/// use bt::{status, BluezClient, StatusError};
+///
+/// let bluez_client = BluezClient::new().unwrap();
+/// let mut output = Cursor::new([]);
+///
+/// let status_result = status(&bluez_client, &mut output);
+///
+/// match status_result {
+///     Err(StatusError::Io(err)) => eprintln!("{}", err),
+///     _ => unreachable!(),
+/// }
+///```
 pub fn status(bluez: &crate::BluezClient, f: &mut impl io::Write) -> Result<(), Error> {
     let power_state = bluez.power_state().map_err(Error::PowerState)?;
     let connected_devs = bluez.connected_devices().map_err(Error::ConnectedDevices)?;


### PR DESCRIPTION
Along with the doc comments, the exports of lib crate is updated to add the missing public faced types to the main bt API.