### PR TITLE
docs(ls): Add doc comments for `list_devices`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -20,19 +20,20 @@ pub enum BtCommand {
     Toggle,
 
     #[clap(visible_alias = "ls")]
+    /// See known Bluetooth devices on the host.
     ListDevices {
         #[command(flatten)]
         args: ListDevicesArgs,
     },
 
-    /// Scan available devices.
+    /// Scan available Bluetooth devices.
     #[clap(visible_alias = "sc")]
     Scan {
         #[command(flatten)]
         args: ScanArgs,
     },
 
-    /// Connect to an available device.
+    /// Connect to an available Bluetooth device.
     #[clap(visible_alias = "c")]
     Connect {
         #[command(flatten)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ mod toggle;
 pub use bluez::{Client as BluezClient, Error as BluezError};
 pub use connect::{ConnectArgs, Error as ConnectError, connect};
 pub use disconnect::{Error as DisconnectError, disconnect};
-pub use list_devices::list_devices;
+pub use list_devices::{
+    DeviceStatus, Error as ListDevicesError, ListDevicesArgs, ListDevicesColumn, list_devices,
+};
 pub use scan::{Error as ScanError, ScanArgs, ScanColumn, scan};
 pub use status::{Error as StatusError, status};
 pub use toggle::{Error as ToggleError, toggle};

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -143,9 +143,9 @@ impl From<&ScanColumn> for String {
 
 /// Provides the ability of scanning available devices by using a [`BluezClient`].
 ///
-/// The list of scanned devices are written to the provided [`io::Write`].
+/// The list is written to the provided [`io::Write`].
 ///
-/// The format of the scanned devices depend on the arguments passed:
+/// The format of the list depends on the arguments passed:
 ///
 /// - If `args.columns` are [`Some`], then [`scan`] uses the pretty formatting, which is a table.
 /// - If `args.values` are [`Some`], then [`scan`] uses the terse formatting, which is a listing where each property of the scanned devices are concatenated by the delimiter `/`.
@@ -181,13 +181,6 @@ impl From<&ScanColumn> for String {
 /// # Errors
 ///
 /// This function can return all variants of [`ScanError`] based on given conditions. For more details, please see the error documentation.
-///
-/// [`BluezClient`]: crate::BluezClient
-/// [`io::Write`]: std::io::Write
-/// [`Some`]: std::option::Option::Some
-/// [`ScanError`]: crate::ScanError
-/// [`scan`]: crate::scan
-/// [`ScanArgs`]: crate::ScanArgs
 ///
 /// # Examples
 ///
@@ -264,6 +257,14 @@ impl From<&ScanColumn> for String {
 ///     _ => unreachable!(),
 /// }
 ///```
+///
+/// [`BluezClient`]: crate::BluezClient
+/// [`io::Write`]: std::io::Write
+/// [`Some`]: std::option::Option::Some
+/// [`None`]: std::option::Option::None
+/// [`ScanError`]: crate::ScanError
+/// [`scan`]: crate::scan
+/// [`ScanArgs`]: crate::ScanArgs
 pub fn scan(
     bluez: &crate::BluezClient,
     f: &mut impl io::Write,


### PR DESCRIPTION
Along with this change, the API for `bt::list_devices` is updated:

- The missing short help text for `bt ls` is added.
- The struct members of `ListDevicesArgs` is set to public to be able to use by the callers.