### PR TITLE
chore(bluez): Add `Error::Process` for BluezClient

### DIFF
--- a/src/bluez/client.rs
+++ b/src/bluez/client.rs
@@ -94,27 +94,25 @@ impl BluezDev {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
-    DBusClient(zbus::Error),
+    Init(zbus::Error),
+    Process(String, zbus::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::DBusClient(error) => {
+            Error::Init(error) => {
                 write!(f, "unable to establish a Bluez D-Bus connection: {}", error)
+            }
+            Error::Process(pid, error) => {
+                write!(f, "the Bluez process '{}' failed: {}", pid, error)
             }
         }
     }
 }
 impl error::Error for Error {}
-
-impl From<zbus::Error> for Error {
-    fn from(value: zbus::Error) -> Self {
-        Self::DBusClient(value)
-    }
-}
 
 pub struct BluezDBusClient {
     connection: Connection,
@@ -123,8 +121,8 @@ pub struct BluezDBusClient {
 
 impl BluezDBusClient {
     pub fn new() -> Result<Self, Error> {
-        let connection = Connection::system()?;
-        let adapter_proxy = BluezAdapterProxy::new(&connection)?;
+        let connection = Connection::system().map_err(Error::Init)?;
+        let adapter_proxy = BluezAdapterProxy::new(&connection).map_err(Error::Init)?;
 
         Ok(Self {
             connection,
@@ -147,29 +145,31 @@ impl BluezDBusClient {
         Ok(dev_paths)
     }
 
-    pub fn power_state(&self) -> zbus::Result<BluezPowerState> {
+    pub fn power_state(&self) -> Result<BluezPowerState, Error> {
         let result = self
             .adapter_proxy
             .power_state()
-            .map(BluezPowerState::from)?;
+            .map(BluezPowerState::from)
+            .map_err(|e| Error::Process(String::from("power_state"), e))?;
 
         Ok(result)
     }
 
-    pub fn toggle_power_state(&self) -> zbus::Result<BluezPowerState> {
-        let prev_state = self
-            .adapter_proxy
-            .power_state()
-            .map(BluezPowerState::from)?;
+    pub fn toggle_power_state(&self) -> Result<BluezPowerState, Error> {
+        let prev_state = self.power_state()?;
 
         let new_state = !prev_state;
-        self.adapter_proxy.set_powered(bool::from(&new_state))?;
+        self.adapter_proxy
+            .set_powered(bool::from(&new_state))
+            .map_err(|e| Error::Process(String::from("toggle_power_state"), e))?;
 
         Ok(new_state)
     }
 
-    pub fn devices(&self) -> zbus::Result<Vec<BluezDev>> {
-        let dev_object_iter = self.dev_object_iter()?;
+    pub fn devices(&self) -> Result<Vec<BluezDev>, Error> {
+        let dev_object_iter = self
+            .dev_object_iter()
+            .map_err(|e| Error::Process(String::from("devices"), e))?;
 
         Ok(dev_object_iter
             .filter_map(|dev_path| {
@@ -203,42 +203,51 @@ impl BluezDBusClient {
             .collect::<Vec<BluezDev>>())
     }
 
-    pub fn connect(&self, alias: &str) -> zbus::Result<()> {
-        let dev_paths = self.dev_object_iter()?;
+    pub fn connect(&self, alias: &str) -> Result<(), Error> {
+        let to_connect_err = |e: zbus::Error| Error::Process(String::from("connect"), e);
+
+        let dev_paths = self.dev_object_iter().map_err(to_connect_err)?;
 
         for dev_path in dev_paths {
-            let dev_proxy = BluezDeviceProxy::new(&self.connection, &dev_path)?;
+            let dev_proxy =
+                BluezDeviceProxy::new(&self.connection, &dev_path).map_err(to_connect_err)?;
 
-            let dev_alias = dev_proxy.alias()?;
+            let dev_alias = dev_proxy.alias().map_err(to_connect_err)?;
             if dev_alias == alias {
-                return dev_proxy.connect();
+                return dev_proxy.connect().map_err(to_connect_err);
             }
         }
 
-        Err(zbus::Error::InterfaceNotFound)
+        Err(to_connect_err(zbus::Error::InterfaceNotFound))
     }
 
-    pub fn connected_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn connected_devices(&self) -> Result<Vec<BluezDev>, Error> {
         let devs = self.devices()?;
 
         Ok(devs.into_iter().filter(|d| d.connected).collect())
     }
 
-    pub fn start_discovery(&self) -> zbus::Result<()> {
-        self.adapter_proxy.start_discovery()
+    pub fn start_discovery(&self) -> Result<(), Error> {
+        self.adapter_proxy
+            .start_discovery()
+            .map_err(|e| Error::Process(String::from("start_disc"), e))
     }
 
-    pub fn stop_discovery(&self) -> zbus::Result<()> {
-        self.adapter_proxy.stop_discovery()
+    pub fn stop_discovery(&self) -> Result<(), Error> {
+        self.adapter_proxy
+            .stop_discovery()
+            .map_err(|e| Error::Process(String::from("stop_disc"), e))
     }
 
-    pub fn scanned_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn scanned_devices(&self) -> Result<Vec<BluezDev>, Error> {
         let devs = self.devices()?;
         Ok(devs.into_iter().filter(|d| d.rssi.is_some()).collect())
     }
 
-    pub fn remove(&self, alias: &str) -> zbus::Result<()> {
-        let mut dev_object_iter = self.dev_object_iter()?;
+    pub fn remove(&self, alias: &str) -> Result<(), Error> {
+        let to_remove_err = |e: zbus::Error| Error::Process(String::from("remove"), e);
+
+        let mut dev_object_iter = self.dev_object_iter().map_err(to_remove_err)?;
 
         let dev_object = dev_object_iter.find_map(|obj| {
             let dev_object = obj.into_inner();
@@ -252,14 +261,18 @@ impl BluezDBusClient {
         });
 
         if let Some(dev_object) = dev_object {
-            self.adapter_proxy.remove_device(dev_object)
+            self.adapter_proxy
+                .remove_device(dev_object)
+                .map_err(to_remove_err)
         } else {
-            Err(zbus::Error::InterfaceNotFound)
+            Err(to_remove_err(zbus::Error::InterfaceNotFound))
         }
     }
 
-    pub fn disconnect(&self, alias: &str) -> zbus::Result<()> {
-        let mut dev_object_iter = self.dev_object_iter()?;
+    pub fn disconnect(&self, alias: &str) -> Result<(), Error> {
+        let to_disconnect_err = |e: zbus::Error| Error::Process(String::from("disconnect"), e);
+
+        let mut dev_object_iter = self.dev_object_iter().map_err(to_disconnect_err)?;
 
         let dev_proxy = dev_object_iter.find_map(|obj| {
             let dev_object = obj.into_inner();
@@ -273,23 +286,23 @@ impl BluezDBusClient {
         });
 
         if let Some(dev_proxy) = dev_proxy {
-            dev_proxy.disconnect()
+            dev_proxy.disconnect().map_err(to_disconnect_err)
         } else {
-            Err(zbus::Error::InterfaceNotFound)
+            Err(to_disconnect_err(zbus::Error::InterfaceNotFound))
         }
     }
 }
 
 pub struct BluezTestClient {
     erred_method_name: Option<String>,
-    err: zbus::Error,
+    err: Error,
 }
 
 impl BluezTestClient {
     pub fn new() -> Result<Self, Error> {
         Ok(Self {
             erred_method_name: None,
-            err: zbus::Error::InvalidReply,
+            err: Error::Process(String::from("test_proc"), zbus::Error::InvalidReply),
         })
     }
 
@@ -297,7 +310,7 @@ impl BluezTestClient {
         self.erred_method_name = Some(name);
     }
 
-    pub fn power_state(&self) -> zbus::Result<BluezPowerState> {
+    pub fn power_state(&self) -> Result<BluezPowerState, Error> {
         let err_key = String::from("power_state");
 
         match &self.erred_method_name {
@@ -306,7 +319,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn toggle_power_state(&self) -> zbus::Result<BluezPowerState> {
+    pub fn toggle_power_state(&self) -> Result<BluezPowerState, Error> {
         let err_key = String::from("toggle_power_state");
 
         match &self.erred_method_name {
@@ -315,7 +328,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn devices(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn devices(&self) -> Result<Vec<BluezDev>, Error> {
         let err_key = String::from("devices");
 
         match &self.erred_method_name {
@@ -337,7 +350,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn connect(&self, _: &str) -> zbus::Result<()> {
+    pub fn connect(&self, _: &str) -> Result<(), Error> {
         let err_key = String::from("connect");
 
         match &self.erred_method_name {
@@ -346,7 +359,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn connected_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn connected_devices(&self) -> Result<Vec<BluezDev>, Error> {
         let err_key = String::from("connected_devices");
 
         match &self.erred_method_name {
@@ -368,7 +381,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn start_discovery(&self) -> zbus::Result<()> {
+    pub fn start_discovery(&self) -> Result<(), Error> {
         let err_key = String::from("start_discovery");
 
         match &self.erred_method_name {
@@ -377,7 +390,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn stop_discovery(&self) -> zbus::Result<()> {
+    pub fn stop_discovery(&self) -> Result<(), Error> {
         let err_key = String::from("stop_discovery");
 
         match &self.erred_method_name {
@@ -386,7 +399,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn scanned_devices(&self) -> zbus::Result<Vec<BluezDev>> {
+    pub fn scanned_devices(&self) -> Result<Vec<BluezDev>, Error> {
         let err_key = String::from("scanned_devices");
 
         match &self.erred_method_name {
@@ -408,7 +421,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn remove(&self, _: &str) -> zbus::Result<()> {
+    pub fn remove(&self, _: &str) -> Result<(), Error> {
         let err_key = String::from("remove");
 
         match &self.erred_method_name {
@@ -417,7 +430,7 @@ impl BluezTestClient {
         }
     }
 
-    pub fn disconnect(&self, _: &str) -> zbus::Result<()> {
+    pub fn disconnect(&self, _: &str) -> Result<(), Error> {
         let err_key = String::from("disconnect");
 
         match &self.erred_method_name {

--- a/src/bluez/mod.rs
+++ b/src/bluez/mod.rs
@@ -1,12 +1,10 @@
 mod client;
 mod proxies;
 
-pub use client::BluezDev as Device;
+pub use client::{BluezDev as Device, Error};
 
 #[cfg(not(test))]
 pub use client::BluezDBusClient as Client;
 
 #[cfg(test)]
 pub use client::BluezTestClient as Client;
-
-pub use zbus::Error;


### PR DESCRIPTION
Whilist adding doc comments, I've realized that the error handling for BluezDBusClient is a bit cumbersome:

- `Error` holds a single variant which represents the errors that may happen during `BluezClient::new()`. This variant holds `zbus::Error`.
- `Error` does not specify all variants that may be returned from interacting with `BluezClient`. For other cases, `zbus::Error` is returned directly.
- All the modules that use `BluezClient` needs custom error variants and mapping just to specify which `BluezClient` process failed.

In order to justify using the `Error` enum, the errors originated from `BluezClient` is put into two variants:

- `Error::Init` for errors that may happen during the initialization of `BluezClient`.
- `Error::Process` for errors that may happen during any instance of a `BluezDBusClient` process.

`Error::Process` allows the `bluez` module to tell "where" the error comes from through a "process id". This id set to be the corresponding method name for now.

Adding `Error::Process` makes all the custom `BluezClient` specific error variants and their error mappings in other modules redundant. Therefore, the redundant errors in other modules are removed and simply replaced with a generic `Bluez(BluezError)` variant.