### PR TITLE
feat(cicd): Add the release pipeline for `bt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: "bt - CI"
+run-name: bt- CI on ${{ github.ref }} @${{ github.actor }}
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  integrity_checks:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run clippy
+        run: |
+          ./exec lint
+        shell: bash
+
+      - name: Run all tests
+        run: |
+          ./exec test
+        shell: bash
+        env:
+          RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: "bt - Release"
+run-name: "bt - Release on ${{ github.ref }}"
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GIT_TAG: ${{ github.ref_name }}
+
+jobs:
+  integrity_checks:
+    uses: ./.github/workflows/ci.yml
+
+  create_release:
+    runs-on: ubuntu-24.04
+    needs: integrity_checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create release
+        run: |
+          gh release create "$GIT_TAG" --verify-tag --draft --title "$GIT_TAG"
+
+        shell: bash
+
+
+  archive:        
+    runs-on: ubuntu-24.04
+    needs: create_release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create release binary
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          ./exec build "$RUST_TARGET"
+          
+        shell: bash
+
+      - name: Archive release binary
+        id: create-archive
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          name="bt-$RUST_TARGET-$GIT_TAG.tar.gz"
+          path="./target/$RUST_TARGET/release/$name"
+
+          ./exec create_archive "$RUST_TARGET" "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Create checksum
+        id: create-checksum
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          name="bt-$RUST_TARGET-$GIT_TAG.sha256sum"
+          path="./target/$RUST_TARGET/release/$name"
+
+          ./exec create_checksum "$RUST_TARGET" "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts to the release
+        env:
+          ARCHIVE_PATH: ${{ steps.create-archive.outputs.path }}
+          CHECKSUM_PATH: ${{ steps.create-checksum.outputs.path }}
+        run: |
+          gh release upload "$GIT_TAG" \
+            "$ARCHIVE_PATH" \
+            "$CHECKSUM_PATH"
+          
+        shell: bash
+
+      - name: Rollback release on failure
+        if: failure()
+        run: |
+          gh release delete "$GIT_TAG" -y --cleanup-tag        

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "bt"
 version = "0.1.0"
+authors = ["Berk Acikgoz <acikgozb@proton.me>"]
 edition = "2024"
+description = "A CLI for managing bluetooth devices through Bluez D-Bus."
+repository = "https://github.com/acikgozb/bt"
 
 [dependencies]
 clap = { version = "4.5.39", features = ["derive"] }
 tabled = { version = "0.19.0", features = ["std", "ansi"] }
 zbus = { version = "5.7.1", default-features = false, features = ["tokio", "blocking-api"] }
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1


### PR DESCRIPTION
2 new workflows are added:

- `ci.yml`: Runs the linter and executes the tests to ensure that code is in proper state. Runs on each PR and during the release.

- `release.yml`: Runs the integrity checks explained above and creates a release archive containing the binary, and the checksum of the current version. It then creates a new Github release and attaches these artifacts to it.

These pipelines are using the helper `exec` script defined in [here](https://github.com/acikgozb/bt/pull/33).

Additionally, the default "release" profile of Cargo is updated to optimize the release binary.